### PR TITLE
Add Python 3.x compatibility pip installs to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ services:
 install:
     - bash bin/travis-build.bash
     - pip install coveralls
+    - pip install future
+    - pip install six
 script: sh bin/travis-run.sh
 after_success:
     - coveralls


### PR DESCRIPTION
Just adds some pip statements to travis to handle Python 2/3 compatibility.