### PR TITLE
Private search

### DIFF
--- a/ckanext/vitality_prototype/plugin.py
+++ b/ckanext/vitality_prototype/plugin.py
@@ -69,7 +69,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def organization_member_create(self, action, context, data_dict=None):
-        log.info("A member has been added!")
+        log.info("A member has been added by %s", context['auth_user_obj'].name)
         org_id= data_dict['id']
         user_id = self.meta_authorize.get_user_by_username(data_dict['username'])['id']
         # Get roles for org
@@ -82,7 +82,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def organization_member_delete(self, action, context, data_dict=None):
-        log.info("A member has been deleted")
+        log.info("A member has been deleted by %s", context['auth_user_obj'].name)
         org_id= data_dict['id']
         user_id = data_dict['user_id']
         log.info("Collected ids")
@@ -95,7 +95,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
     # Triggers when a user's information is updated (name/email)
     @toolkit.chained_action
     def user_update(self, action, context, data_dict=None):
-        log.info("An user has been edited")
+        log.info("An user has been edited by %s", context['auth_user_obj'].name)
         ckan_user_info = toolkit.get_action('user_show')(context,data_dict)
         neo4j_user_info = self.meta_authorize.get_user(ckan_user_info['id'])
         # Unsure if username can be changed, but this can work around it if so
@@ -110,7 +110,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
     @toolkit.chained_action
     def user_create(self, action, context, data_dict=None):
         result = action(context, data_dict)
-        log.info("A user has been created")
+        log.info("A user has been created by %s", context['auth_user_obj'].name)
         user_id = result['id']
         user_name = result['name']
         user_email = result['email']
@@ -122,7 +122,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def user_delete(self, action, context, data_dict=None):
-        log.info("An user has been deleted")
+        log.info("An user has been deleted by %s", context['auth_user_obj'].name)
         user_id = data_dict['id']
         self.meta_authorize.delete_user(user_id)
         return action(context, data_dict)
@@ -130,20 +130,19 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
     # Triggers when an org's information is updated (name)
     @toolkit.chained_action
     def organization_update(self, action, context, data_dict=None):
-        log.info("An organization has been edited")
+        log.info("An organization has been edited by %s", context['auth_user_obj'].name)
         ckan_org_info = toolkit.get_action('organization_show')(context, data_dict)
         ckan_org_id= ckan_org_info['id']
         ckan_org_name = data_dict['name']
         neo4j_org_name = self.meta_authorize.get_organization(ckan_org_id)['name']
         if(neo4j_org_name != ckan_org_name):
-            log.info("Org name has been updated")
             self.meta_authorize.set_organization_name(ckan_org_id, ckan_org_name)
             org_name = self.meta_authorize.get_organization(ckan_org_id)['name']
         return action(context, data_dict)      
 
     @toolkit.chained_action
     def organization_create(self, action, context, data_dict=None):
-        log.info("An organization has been created")
+        log.info("An organization has been created by %s", context['auth_user_obj'].name)
         result = action(context, data_dict)
         org_name = data_dict['title_translated-en']
         org_id = result['id']
@@ -160,7 +159,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def organization_delete(self, action, context, data_dict=None):
-        log.info("An organization has been deleted")
+        log.info("An organization has been deleted by %s", context['auth_user_obj'].name)
         organization_id = data_dict['id']
         result = action(context, data_dict)
         self.meta_authorize.delete_organization(organization_id)
@@ -168,7 +167,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def package_update(self, action, context, data_dict=None):
-        log.info("A package has been updated")
+        log.info("A package has been updated by %s", context['auth_user_obj'].name)
         result = action(context, data_dict)
         if(result['type'] != 'dataset'):
             log.info("Updated package not a dataset")
@@ -189,7 +188,7 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
 
     @toolkit.chained_action
     def package_delete(action, context, data_dict=None):
-        log.info("An package has been deleted")
+        log.info("An package has been deleted by %s", context['auth_user_obj'].name)
         # Only needs to track description?
         # Delete all the templates and attributes associated too
         result = action(context, data_dict)

--- a/ckanext/vitality_prototype/plugin.py
+++ b/ckanext/vitality_prototype/plugin.py
@@ -349,6 +349,8 @@ class Vitality_PrototypePlugin(plugins.SingletonPlugin):
                         x= '(tags_fr:"' + tags + '" OR ' + tags_private + ')'
                     final_query += x + ' '
                 search_params['fq'] = final_query.strip()
+            else:
+                search_params['fq'] = final_query.strip()    
         return search_params
 
 

--- a/ckanext/vitality_prototype/templates/scheming/package/read.html
+++ b/ckanext/vitality_prototype/templates/scheming/package/read.html
@@ -14,7 +14,7 @@
         {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
     </div>
     {% endif %}
-    {% if pkg.res_extras_keywords_private %}
+    {% if pkg.res_extras_keywords_restricted or pkg.res_extras_eov_restricted %}
         <p>
             <h3>This dataset contains restricted information</h3>
             You can contact the dataset owner to request access
@@ -24,7 +24,7 @@
 {% endblock %}
 
   {% block package_tags %}
-    {% if pkg.res_extras_keywords_private %}
+    {% if pkg.res_extras_keywords_restricted %}
         <p>
         Open Variables:
         </p>
@@ -32,7 +32,7 @@
         <p>
         Restricted Variables:
         </p>
-        {% snippet "package/snippets/tags.html", tags=pkg.res_extras_keywords_private['en'] %}
+        {% snippet "package/snippets/tags.html", tags=pkg.res_extras_keywords_restricted['en'] %}
     {% else %}
         {% snippet "package/snippets/tags.html", tags=pkg.tags %}
     {% endif %}

--- a/ckanext/vitality_prototype/templates/scheming/package/read.html
+++ b/ckanext/vitality_prototype/templates/scheming/package/read.html
@@ -14,6 +14,12 @@
         {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
     </div>
     {% endif %}
+    {% if pkg.res_extras_keywords_private %}
+        <p>
+            <h3>This dataset contains restricted information</h3>
+            You can contact the dataset owner to request access
+        </p>
+    {% endif %}
 
 {% endblock %}
 

--- a/ckanext/vitality_prototype/templates/snippets/package_item.html
+++ b/ckanext/vitality_prototype/templates/snippets/package_item.html
@@ -1,0 +1,65 @@
+{% ckan_extends %}
+
+{% block package_item %}
+  <li class="{{ item_class or "dataset-item" }}">
+    {% block content %}
+      <div class="dataset-content">
+        {% block heading %}
+          <h3 class="dataset-heading">
+            {% block heading_private %}
+              {% if package.private %}
+                <span class="dataset-private label label-inverse">
+                  <i class="fa fa-lock"></i>
+                  {{ _('Private') }}
+                </span>
+              {% elif package.res_extras_keywords_private or package.res_extras_eov_private %}
+                <span class="dataset-restricted label label-inverse">
+                  <i class="fa fa-lock"></i>
+                  {{ _('Restricted') }}
+                </span>
+              {% endif %}
+            {% endblock %}
+            {% block heading_title %}
+              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type + '_read', controller='package', action='read', id=package.name)) }}
+            {% endblock %}
+            {% block heading_meta %}
+              {% if package.get('state', '').startswith('draft') %}
+                <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('state', '').startswith('deleted') %}
+                <span class="label label-danger">{{ _('Deleted') }}</span>
+              {% endif %}
+              {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+            {% endblock %}
+          </h3>
+        {% endblock %}
+        {% block banner %}
+          {% if banner %}
+            <span class="banner">{{ _('Popular') }}</span>
+          {% endif %}
+        {% endblock %}
+        {% block notes %}
+          {% if notes %}
+            <div>{{ notes|urlize }}</div>
+          {% else %}
+            <p class="empty">{{ _("This dataset has no description") }}</p>
+          {% endif %}
+        {% endblock %}
+      </div>
+      {% block resources %}
+        {% if package.resources and not hide_resources %}
+          {% block resources_outer %}
+            <ul class="dataset-resources list-unstyled">
+              {% block resources_inner %}
+                {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+                <li>
+                  <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}" class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</a>
+                </li>
+                {% endfor %}
+              {% endblock %}
+            </ul>
+          {% endblock %}
+        {% endif %}
+      {% endblock %}
+    {% endblock %}
+  </li>
+{% endblock %}

--- a/ckanext/vitality_prototype/templates/snippets/package_item.html
+++ b/ckanext/vitality_prototype/templates/snippets/package_item.html
@@ -1,65 +1,16 @@
 {% ckan_extends %}
 
-{% block package_item %}
-  <li class="{{ item_class or "dataset-item" }}">
-    {% block content %}
-      <div class="dataset-content">
-        {% block heading %}
-          <h3 class="dataset-heading">
-            {% block heading_private %}
-              {% if package.private %}
-                <span class="dataset-private label label-inverse">
-                  <i class="fa fa-lock"></i>
-                  {{ _('Private') }}
-                </span>
-              {% elif package.mark_restricted %}
-                <span class="dataset-restricted label label-inverse">
-                  <i class="fa fa-lock"></i>
-                  {{ _('Restricted') }}
-                </span>
-              {% endif %}
-            {% endblock %}
-            {% block heading_title %}
-              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type + '_read', controller='package', action='read', id=package.name)) }}
-            {% endblock %}
-            {% block heading_meta %}
-              {% if package.get('state', '').startswith('draft') %}
-                <span class="label label-info">{{ _('Draft') }}</span>
-              {% elif package.get('state', '').startswith('deleted') %}
-                <span class="label label-danger">{{ _('Deleted') }}</span>
-              {% endif %}
-              {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
-            {% endblock %}
-          </h3>
-        {% endblock %}
-        {% block banner %}
-          {% if banner %}
-            <span class="banner">{{ _('Popular') }}</span>
-          {% endif %}
-        {% endblock %}
-        {% block notes %}
-          {% if notes %}
-            <div>{{ notes|urlize }}</div>
-          {% else %}
-            <p class="empty">{{ _("This dataset has no description") }}</p>
-          {% endif %}
-        {% endblock %}
-      </div>
-      {% block resources %}
-        {% if package.resources and not hide_resources %}
-          {% block resources_outer %}
-            <ul class="dataset-resources list-unstyled">
-              {% block resources_inner %}
-                {% for resource in h.dict_list_reduce(package.resources, 'format') %}
-                <li>
-                  <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}" class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</a>
-                </li>
-                {% endfor %}
-              {% endblock %}
-            </ul>
-          {% endblock %}
-        {% endif %}
-      {% endblock %}
-    {% endblock %}
-  </li>
+
+{% block heading_private %}
+    {% if package.private %}
+    <span class="dataset-private label label-inverse">
+        <i class="fa fa-lock"></i>
+        {{ _('Private') }}
+    </span>
+    {% elif package.mark_restricted %}
+    <span class="dataset-restricted label label-inverse">
+        <i class="fa fa-lock"></i>
+        {{ _('Restricted') }}
+    </span>
+    {% endif %}
 {% endblock %}

--- a/ckanext/vitality_prototype/templates/snippets/package_item.html
+++ b/ckanext/vitality_prototype/templates/snippets/package_item.html
@@ -12,7 +12,7 @@
                   <i class="fa fa-lock"></i>
                   {{ _('Private') }}
                 </span>
-              {% elif package.res_extras_keywords_private or package.res_extras_eov_private %}
+              {% elif package.mark_restricted %}
                 <span class="dataset-restricted label label-inverse">
                   <i class="fa fa-lock"></i>
                   {{ _('Restricted') }}

--- a/ckanext/vitality_prototype/templates/snippets/search_form.html
+++ b/ckanext/vitality_prototype/templates/snippets/search_form.html
@@ -17,9 +17,9 @@
     <br></br>
     {% if h.get_request_param('eov') or h.get_request_param('tags_en') or h.get_request_param('tags_fr') or h.get_request_param('tags')%}
         {% if h.get_request_param('restricted_search') %}
-            <span class="dataset-heading"><a href = {{h.remove_url_param(key = 'restricted_search')}}>Hide entries with private records</a>.</span>
+            <span class="dataset-heading"><a href = {{h.remove_url_param(key = 'restricted_search')}}>Hide entries with restricted records</a>.</span>
         {% else %}
-            <span class="dataset-heading"><a href = {{h.add_url_param(new_params={'restricted_search':'enabled'})}}>Show entries with private records</a>.</span>
+            <span class="dataset-heading"><a href = {{h.add_url_param(new_params={'restricted_search':'enabled'})}}>Show entries with restricted records</a>.</span>
         {% endif %}
     {% endif %}
     </div>

--- a/ckanext/vitality_prototype/templates/snippets/search_form.html
+++ b/ckanext/vitality_prototype/templates/snippets/search_form.html
@@ -15,12 +15,10 @@
     <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
     {% endblock %}
     <br></br>
-    {% if h.get_request_param('eov') or h.get_request_param('tags_en') or h.get_request_param('tags_fr') or h.get_request_param('tags')%}
-        {% if h.get_request_param('restricted_search') %}
-            <span class="dataset-heading"><a href = {{h.remove_url_param(key = 'restricted_search')}}>Hide entries with restricted records</a>.</span>
-        {% else %}
-            <span class="dataset-heading"><a href = {{h.add_url_param(new_params={'restricted_search':'enabled'})}}>Show entries with restricted records</a>.</span>
-        {% endif %}
+    {% if h.get_request_param('restricted_search') %}
+        <span class="dataset-heading"><a href = {{h.remove_url_param(key = 'restricted_search')}}>Hide entries with restricted records</a>.</span>
+    {% elif h.get_request_param('eov') or h.get_request_param('tags_en') or h.get_request_param('tags_fr') or h.get_request_param('tags') %}
+        <span class="dataset-heading"><a href = {{h.add_url_param(new_params={'restricted_search':'enabled'})}}>Show entries with restricted records</a>.</span>
     {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
- Warnings for restricted elements will only appear if the search criteria matches one of the restricted metadata variables
- Changed the 'restricted' marker to act similar to the 'private' marker, instead of treating as a resource
- Notice that a dataset contains restricted elements now appears on the dataset page
- Updated variable names and descriptors to be 'restricted' instead of 'private'
- Updated logging information to more accurately display changes to packages